### PR TITLE
Make single reducer also return object / JET_CLOSE reset

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -172,9 +172,9 @@ export const array = (id, initialState = []) => (state = initialState, action) =
       if (action.expression.sort) {
         return _sorted(state, action)
       } else {
-        const {path, event, value} = action.data[0]
+        const {path, event, value, fetchOnly = false} = action.data[0]
         if (event === 'add') {
-          return [...state, {path, value}]
+          return [...state, {path, value, fetchOnly}]
         } else if (event === 'change') {
           const index = state.findIndex(e => e.path === path)
           return [
@@ -231,11 +231,11 @@ export const unsorted = (id, initialState = {}) => (state = initialState, action
       return action.result
     case 'JET_FETCHER_DATA':
       let newState = {...state}
-      const {path, value, event} = action.data[0]
+      const {path, value, event, fetchOnly = false} = action.data[0]
       if (event === 'remove') {
         delete newState[path]
       } else {
-        newState[path] = {...newState[path], value}
+        newState[path] = {...newState[path], value, fetchOnly}
       }
       return newState
     default:
@@ -266,6 +266,10 @@ export const unsorted = (id, initialState = {}) => (state = initialState, action
  *
  */
 export const single = (id, initialState = null) => (state = initialState, action) => {
+  const element = handleRequestResponse(action, () => state && state.path === action.path && state)
+  if (element) {
+    return element
+  }
   if (action.id !== id) {
     return state
   }
@@ -275,11 +279,11 @@ export const single = (id, initialState = null) => (state = initialState, action
     case 'JET_UNFETCH':
       return null
     case 'JET_GET_SUCCESS':
-      return action.result[0] ? action.result[0].value : null
+      return action.result[0] ? action.result[0] : null
     case 'JET_FETCHER_DATA':
-      const {value, event} = action.data[0]
+      const {value, event, fetchOnly = false, path} = action.data[0]
       if (event === 'add' || event === 'change') {
-        return value
+        return {value, fetchOnly, path}
       } else {
         return null
       }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -58,6 +58,7 @@ const _sorted = (state = [], action) => {
     case 'JET_FETCHER_FAILURE':
     case 'JET_GET_FAILURE':
     case 'JET_UNFETCH':
+    case 'JET_CLOSE':
       return []
     case 'JET_GET_SUCCESS':
       return action.result
@@ -119,7 +120,7 @@ export const sorted = (id, initialState = []) => (state = initialState, action) 
       ...state.slice(index + 1)
     ]
   }
-  if (action.id !== id) {
+  if (action.type !== 'JET_CLOSE' && action.id !== id) {
     return state
   }
   return _sorted(state, action)
@@ -158,13 +159,14 @@ export const array = (id, initialState = []) => (state = initialState, action) =
       ...state.slice(index + 1)
     ]
   }
-  if (action.id !== id) {
+  if (action.type !== 'JET_CLOSE' && action.id !== id) {
     return state
   }
   switch (action.type) {
     case 'JET_FETCHER_FAILURE':
     case 'JET_GET_FAILURE':
     case 'JET_UNFETCH':
+    case 'JET_CLOSE':
       return []
     case 'JET_GET_SUCCESS':
       return action.result
@@ -219,14 +221,15 @@ export const unsorted = (id, initialState = {}) => (state = initialState, action
   if (element) {
     return {...state, [action.path]: element}
   }
-  if (action.id !== id) {
+  if (action.type !== 'JET_CLOSE' && action.id !== id) {
     return state
   }
   switch (action.type) {
     case 'JET_FETCHER_FAILURE':
     case 'JET_GET_FAILURE':
     case 'JET_UNFETCH':
-      return []
+    case 'JET_CLOSE':
+      return {}
     case 'JET_GET_SUCCESS':
       return action.result
     case 'JET_FETCHER_DATA':
@@ -270,13 +273,14 @@ export const single = (id, initialState = null) => (state = initialState, action
   if (element) {
     return element
   }
-  if (action.id !== id) {
+  if (action.type !== 'JET_CLOSE' && action.id !== id) {
     return state
   }
   switch (action.type) {
     case 'JET_FETCHER_FAILURE':
     case 'JET_GET_FAILURE':
     case 'JET_UNFETCH':
+    case 'JET_CLOSE':
       return null
     case 'JET_GET_SUCCESS':
       return action.result[0] ? action.result[0] : null
@@ -339,6 +343,8 @@ export const request = (state, action) => {
 export const requests = (maxLength = 100) => (state = [], action) => {
   const start = state.length - maxLength
   switch (action.type) {
+    case 'JET_CLOSE':
+      return []
     case 'JET_SET_REQUEST':
     case 'JET_CALL_REQUEST':
       return [

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -562,7 +562,8 @@ describe('reducers', () => {
         },
         {
           path: 'foo',
-          value: 123
+          value: 123,
+          fetchOnly: false
         }
       ])
     })
@@ -674,12 +675,13 @@ describe('reducers', () => {
         data: [{
           path: 'bla',
           value: 123,
-          event: 'add'
+          event: 'add',
+          fetchOnly: true
         }],
         id: 'foo'
       }
       const state = unsorted('foo')(undefined, action)
-      assert.deepEqual(state, {bla: {value: 123}})
+      assert.deepEqual(state, {bla: {value: 123, fetchOnly: true}})
     })
 
     it('returns object with data from JET_FETCHER_DATA / change event', () => {
@@ -693,7 +695,7 @@ describe('reducers', () => {
         id: 'foo'
       }
       const state = unsorted('foo')({bla: {value: 333}}, action)
-      assert.deepEqual(state, {bla: {value: 123}})
+      assert.deepEqual(state, {bla: {value: 123, fetchOnly: false}})
     })
 
     it('returns object with data from JET_FETCHER_DATA / remove event', () => {
@@ -825,7 +827,7 @@ describe('reducers', () => {
         id: 'foo'
       }
       const state = single('foo')(undefined, action)
-      assert.equal(state, 123)
+      assert.deepEqual(state, {value: 123, fetchOnly: false, path: 'bla'})
     })
 
     it('returns object with data.value from JET_FETCHER_DATA / change event', () => {
@@ -839,7 +841,7 @@ describe('reducers', () => {
         id: 'foo'
       }
       const state = single('foo')(undefined, action)
-      assert.equal(state, 123)
+      assert.deepEqual(state, {value: 123, path: 'bla', fetchOnly: false})
     })
 
     it('returns null from JET_FETCHER_DATA / remove event', () => {
@@ -856,6 +858,28 @@ describe('reducers', () => {
       assert.equal(state, null)
     })
 
+    it('adds request entry for JET_CALL_REQUEST action', () => {
+      const action = {
+        type: 'JET_CALL_REQUEST',
+        path: 'bla',
+        args: [333],
+        id: 'ddd'
+      }
+      const initial = {
+        path: 'bla',
+        fetchOnly: true
+      }
+      const state = single('foo')(initial, action)
+      assert.deepEqual(state, {
+        ...initial,
+        request: {
+          pending: true,
+          args: [333],
+          id: 'ddd'
+        }
+      })
+    })
+
     it('JET_GET_SUCCESS sets result', () => {
       const action = {
         type: 'JET_GET_SUCCESS',
@@ -864,7 +888,7 @@ describe('reducers', () => {
         result: [{path: 'hello', value: 'world'}]
       }
       const state = single('bar')([], action)
-      assert.equal(state, 'world')
+      assert.equal(state.value, 'world')
     })
 
     it('returns unmodified state if same id but unknown action.type', () => {

--- a/test/reducer.spec.js
+++ b/test/reducer.spec.js
@@ -192,6 +192,14 @@ describe('reducers', () => {
       assert.deepEqual(req(undefined, {}), [])
     })
 
+    it('JET_CLOSE clears array', () => {
+      const req = requests()
+      const state = req([12, 23], {
+        type: 'JET_CLOSE'
+      })
+      assert.deepEqual(state, [])
+    })
+
     it('push request', () => {
       const req = requests()
       const action = {
@@ -248,6 +256,14 @@ describe('reducers', () => {
   describe('sorted', () => {
     it('default is empty array', () => {
       assert.deepEqual(sorted('foo')(undefined, {}), [])
+    })
+
+    it('JET_CLOSE clears array', () => {
+      const s = sorted('foo')
+      const state = s([12, 23], {
+        type: 'JET_CLOSE'
+      })
+      assert.deepEqual(state, [])
     })
 
     it('returns empty array for JET_FETCHER_FAILURE', () => {
@@ -461,6 +477,14 @@ describe('reducers', () => {
       assert.deepEqual(array('foo')(undefined, {}), [])
     })
 
+    it('JET_CLOSE clears array', () => {
+      const a = array('foo')
+      const state = a([12, 23], {
+        type: 'JET_CLOSE'
+      })
+      assert.deepEqual(state, [])
+    })
+
     it('returns empty array for JET_FETCHER_FAILURE', () => {
       const action = {
         type: 'JET_FETCHER_FAILURE',
@@ -622,6 +646,14 @@ describe('reducers', () => {
   describe('unsorted', () => {
     it('default is empty object', () => {
       assert.deepEqual(unsorted('foo')(undefined, {}), {})
+    })
+
+    it('JET_CLOSE clears object', () => {
+      const u = unsorted('foo')
+      const state = u({x: 123}, {
+        type: 'JET_CLOSE'
+      })
+      assert.deepEqual(state, {})
     })
 
     it('returns empty object for JET_FETCHER_FAILURE', () => {
@@ -790,6 +822,14 @@ describe('reducers', () => {
   describe('single', () => {
     it('default is null', () => {
       assert.equal(single('foo')(undefined, {}), null)
+    })
+
+    it('JET_CLOSE clears state', () => {
+      const s = single('foo')
+      const state = s({x: 123}, {
+        type: 'JET_CLOSE'
+      })
+      assert.deepEqual(state, null)
     })
 
     it('returns null for JET_FETCHER_FAILURE', () => {


### PR DESCRIPTION
Breaking changes:
- `single` reducer now returns state/method instead of state.value
- `JET_CLOSE` (explicit close event resets all reducers)

Fix:
- propagate `fetchOnly` field (closes #16)